### PR TITLE
chore: fix typo

### DIFF
--- a/deploy/crds/tf.isaaguilar.com_terraforms_crd.yaml
+++ b/deploy/crds/tf.isaaguilar.com_terraforms_crd.yaml
@@ -107,6 +107,13 @@ spec:
                     required:
                     - name
                     type: object
+                  serviceAccountAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: ServiceAccountAnnotations allows the service account
+                      to be annotated with cloud IAM roles such as Workload Identity
+                      on GCP
+                    type: object
                 type: object
               type: array
             customBackend:
@@ -253,6 +260,11 @@ spec:
                 - host
                 type: object
               type: array
+            serviceAccount:
+              description: ServiceAccount use a specific kubernetes ServiceAccount
+                for running the create + destroy pods. If not specified we create
+                a new ServiceAccount per Terraform
+              type: string
             sources:
               items:
                 description: SrcOpts defines a terraform source location (eg git::SSH

--- a/pkg/apis/tf/v1alpha1/terraform_types.go
+++ b/pkg/apis/tf/v1alpha1/terraform_types.go
@@ -51,7 +51,7 @@ type TerraformSpec struct {
 
 	// Credentials is an array of credentials generally used for Terraform
 	// providers
-	Credentails []Credentials `json:"credentials,omitempty"`
+	Credentials []Credentials `json:"credentials,omitempty"`
 
 	// ApplyOnCreate is used to apply any planned changes when the resource is
 	// first created. Omitting this or setting it to false will resort to

--- a/pkg/apis/tf/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/tf/v1alpha1/zz_generated.deepcopy.go
@@ -66,6 +66,13 @@ func (in *Credentials) DeepCopyInto(out *Credentials) {
 	*out = *in
 	out.SecretNameRef = in.SecretNameRef
 	out.AWSCredentials = in.AWSCredentials
+	if in.ServiceAccountAnnotations != nil {
+		in, out := &in.ServiceAccountAnnotations, &out.ServiceAccountAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 
@@ -420,10 +427,12 @@ func (in *TerraformSpec) DeepCopyInto(out *TerraformSpec) {
 		*out = make([]EnvVar, len(*in))
 		copy(*out, *in)
 	}
-	if in.Credentails != nil {
-		in, out := &in.Credentails, &out.Credentails
+	if in.Credentials != nil {
+		in, out := &in.Credentials, &out.Credentials
 		*out = make([]Credentials, len(*in))
-		copy(*out, *in)
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.Reconcile != nil {
 		in, out := &in.Reconcile, &out.Reconcile

--- a/pkg/controller/terraform/terraform_controller.go
+++ b/pkg/controller/terraform/terraform_controller.go
@@ -605,7 +605,7 @@ func (r *ReconcileTerraform) setupAndRun(reqLogger logr.Logger, instance *tfv1al
 	reqLogger.Info("Reading spec.config ")
 	// TODO Validate spec.config exists
 	// TODO validate spec.sources exists && len > 0
-	runOpts.credentials = instance.Spec.Credentails
+	runOpts.credentials = instance.Spec.Credentials
 	tfvars := ""
 	otherConfigFiles := make(map[string]string)
 	for _, s := range instance.Spec.Sources {


### PR DESCRIPTION
`credentails` -=> `credentials`