### PR TITLE
Finish removing metrics server

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,12 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
-// Change below variables to serve metrics on different host or port.
-var (
-	metricsHost               = "0.0.0.0"
-	metricsPort         int32 = 8383
-	operatorMetricsPort int32 = 8686
-)
 var log = ctrl.Log.WithName("setup")
 
 func printVersion() {
@@ -88,7 +82,7 @@ func main() {
 	mgr, err := manager.New(cfg, manager.Options{
 		Namespace:          namespace,
 		MapperProvider:     apiutil.NewDiscoveryRESTMapper,
-		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		MetricsBindAddress: "0", // set to "0" to disable the metrics serving
 	})
 	if err != nil {
 		log.Error(err, "")

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,7 +20,7 @@ spec:
           image: isaaguilar/terraform-operator:v0.0.0
           command:
           - terraform-operator
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             ## WATCH_NAMESPACE is not yet supported, leave as blank
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
- Some metrics bits were still there and the Metrics Server is started unnecessarily.
- Change `ImagePullPolicy` to `IfNotPresent` in deploy/operator.yaml as there is an old `v0.0.0` image on Docker Hub (it was always picked instead of mine thus preventing to deploy my local image)