### PR TITLE
created an "entrypoint script" override

### DIFF
--- a/deploy/crds/tf.isaaguilar.com_terraforms_crd.yaml
+++ b/deploy/crds/tf.isaaguilar.com_terraforms_crd.yaml
@@ -383,6 +383,25 @@ spec:
               type: array
             scriptRunner:
               type: string
+            scriptRunnerExecutionScriptConfigMap:
+              description: ScriptRunnerExecutionScriptConfigMap allows the user to
+                define a custom terraform runner script that gets executed instead
+                of the default script built into the runner image. The configmap "name"
+                and "key" are required.
+              properties:
+                key:
+                  description: The key to select.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                  type: string
+                optional:
+                  description: Specify whether the ConfigMap or its key must be defined
+                  type: boolean
+              required:
+              - key
+              type: object
             scriptRunnerPullPolicy:
               description: PullPolicy describes a policy for if/when to pull a container
                 image
@@ -396,6 +415,25 @@ spec:
               type: string
             setupRunner:
               type: string
+            setupRunnerExecutionScriptConfigMap:
+              description: SetupRunnerExecutionScriptConfigMap allows the user to
+                define a custom terraform runner script that gets executed instead
+                of the default script built into the runner image. The configmap "name"
+                and "key" are required.
+              properties:
+                key:
+                  description: The key to select.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                  type: string
+                optional:
+                  description: Specify whether the ConfigMap or its key must be defined
+                  type: boolean
+              required:
+              - key
+              type: object
             setupRunnerPullPolicy:
               description: PullPolicy describes a policy for if/when to pull a container
                 image
@@ -479,6 +517,25 @@ spec:
                 users who need to have a certain toolset installed on their images,
                 or who can't pull public images, such as the default image "isaaguilar/tfops".
               type: string
+            terraformRunnerExecutionScriptConfigMap:
+              description: TerraformRunnerExecutionScriptConfigMap allows the user
+                to define a custom terraform runner script that gets executed instead
+                of the default script built into the runner image. The configmap "name"
+                and "key" are required.
+              properties:
+                key:
+                  description: The key to select.
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                  type: string
+                optional:
+                  description: Specify whether the ConfigMap or its key must be defined
+                  type: boolean
+              required:
+              - key
+              type: object
             terraformRunnerPullPolicy:
               description: TerraformRunnerPullPolicy describes a policy for if/when
                 to pull the TerraformRunner image. Acceptable values are "Always",

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: terraform-operator
           # Replace this with the built image name
-          image: isaaguilar/terraform-operator:v0.0.0
+          image: localhost:5000/terraform-operator:v0.0.0
           command:
           - terraform-operator
           imagePullPolicy: IfNotPresent

--- a/examples/complete-examples/simple-template.yaml
+++ b/examples/complete-examples/simple-template.yaml
@@ -20,9 +20,6 @@ spec:
         in_cluster_config  = true
       }
     }
-  applyOnCreate: true
-  applyOnUpdate: true
-  applyOnDelete: true
   ignoreDelete: false
   
   ## Optionally pull some tfvars from a file. For this, "extras" must be "['is-file']"
@@ -39,16 +36,31 @@ spec:
     value: example
   
   # Print hello before running terraform
-  prerunScript: |-
-    #!/usr/bin/env bash
-    
-    echo "Hello, I am here -> $(pwd)"
+  #prerunScript: |-
+  #  #!/usr/bin/env bash
+  #  
+  #  echo "Hello, I am here -> $(pwd)"
     
   
   # Sleep after running terraform just as an example. 
-  postrunScript: |-
-    #!/usr/bin/env bash
-    
-    cd "/$TFOPS_MAIN_MODULE"
-    terraform_output_id=$(terraform output id)
-    echo "$terraform_output_id Terraform is done!" 
+  #postrunScript: |-
+  #  #!/usr/bin/env bash
+  #  
+  #  cd "/$TFOPS_MAIN_MODULE"
+  #  terraform_output_id=$(terraform output id)
+  #  echo "$terraform_output_id Terraform is done!" 
+
+  setupRunnerExecutionScriptConfigMap:
+    name: tfexe
+    key: setup
+    optional: false
+  
+  scriptRunnerExecutionScriptConfigMap:
+    name: tfexe
+    key: script
+    optional: false
+  
+  terraformRunnerExecutionScriptConfigMap:
+    name: tfexe
+    key: tf
+    optional: false

--- a/pkg/apis/tf/v1alpha1/terraform_types.go
+++ b/pkg/apis/tf/v1alpha1/terraform_types.go
@@ -48,6 +48,24 @@ type TerraformSpec struct {
 	ScriptRunner    string `json:"scriptRunner,omitempty"`
 	SetupRunner     string `json:"setupRunner,omitempty"`
 
+	// TerraformRunnerExecutionScriptConfigMap allows the user to define a
+	// custom terraform runner script that gets executed instead of the default
+	// script built into the runner image. The configmap "name" and "key" are
+	// required.
+	TerraformRunnerExecutionScriptConfigMap *corev1.ConfigMapKeySelector `json:"terraformRunnerExecutionScriptConfigMap,omitempty"`
+
+	// ScriptRunnerExecutionScriptConfigMap allows the user to define a
+	// custom terraform runner script that gets executed instead of the default
+	// script built into the runner image. The configmap "name" and "key" are
+	// required.
+	ScriptRunnerExecutionScriptConfigMap *corev1.ConfigMapKeySelector `json:"scriptRunnerExecutionScriptConfigMap,omitempty"`
+
+	// SetupRunnerExecutionScriptConfigMap allows the user to define a
+	// custom terraform runner script that gets executed instead of the default
+	// script built into the runner image. The configmap "name" and "key" are
+	// required.
+	SetupRunnerExecutionScriptConfigMap *corev1.ConfigMapKeySelector `json:"setupRunnerExecutionScriptConfigMap,omitempty"`
+
 	// TerraformRunnerPullPolicy describes a policy for if/when to pull the
 	// TerraformRunner image. Acceptable values are "Always", "Never", or
 	// "IfNotPresent".

--- a/pkg/apis/tf/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/tf/v1alpha1/zz_generated.openapi.go
@@ -89,6 +89,22 @@ func schema_pkg_apis_tf_v1alpha1_TerraformSpec(ref common.ReferenceCallback) com
 				Description: "TerraformSpec defines the desired state of Terraform",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"runnerAnnotations": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RunnerAnnotations are annotations that will be added to all runner pods.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 					"terraformVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TerraformVersion helps the operator decide which image tag to pull for the terraform runner. Defaults to \"0.11.14\"",
@@ -125,6 +141,24 @@ func schema_pkg_apis_tf_v1alpha1_TerraformSpec(ref common.ReferenceCallback) com
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",
+						},
+					},
+					"terraformRunnerExecutionScriptConfigMap": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TerraformRunnerExecutionScriptConfigMap allows the user to define a custom terraform runner script that gets executed instead of the default script built into the runner image. The configmap \"name\" and \"key\" are required.",
+							Ref:         ref("k8s.io/api/core/v1.ConfigMapKeySelector"),
+						},
+					},
+					"scriptRunnerExecutionScriptConfigMap": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ScriptRunnerExecutionScriptConfigMap allows the user to define a custom terraform runner script that gets executed instead of the default script built into the runner image. The configmap \"name\" and \"key\" are required.",
+							Ref:         ref("k8s.io/api/core/v1.ConfigMapKeySelector"),
+						},
+					},
+					"setupRunnerExecutionScriptConfigMap": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SetupRunnerExecutionScriptConfigMap allows the user to define a custom terraform runner script that gets executed instead of the default script built into the runner image. The configmap \"name\" and \"key\" are required.",
+							Ref:         ref("k8s.io/api/core/v1.ConfigMapKeySelector"),
 						},
 					},
 					"terraformRunnerPullPolicy": {
@@ -344,7 +378,7 @@ func schema_pkg_apis_tf_v1alpha1_TerraformSpec(ref common.ReferenceCallback) com
 			},
 		},
 		Dependencies: []string{
-			"github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha1.Credentials", "github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha1.ExportRepo", "github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha1.ProxyOpts", "github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha1.ReconcileTerraformDeployment", "github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha1.SCMAuthMethod", "github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha1.SrcOpts", "k8s.io/api/core/v1.EnvVar"},
+			"github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha1.Credentials", "github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha1.ExportRepo", "github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha1.ProxyOpts", "github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha1.ReconcileTerraformDeployment", "github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha1.SCMAuthMethod", "github.com/isaaguilar/terraform-operator/pkg/apis/tf/v1alpha1.SrcOpts", "k8s.io/api/core/v1.ConfigMapKeySelector", "k8s.io/api/core/v1.EnvVar"},
 	}
 }
 

--- a/terraform-runner/build.sh
+++ b/terraform-runner/build.sh
@@ -12,7 +12,7 @@ DOCKER_REPO=${DOCKER_REPO:-"isaaguilar"}
 ## Build setup-runner
 ##
 export USER_UID=1000
-export DOCKER_IMAGE="$DOCKER_REPO/setup-runner-alphav1:1.0.0"
+export DOCKER_IMAGE="$DOCKER_REPO/setup-runner-alphav2:1.0.0"
 printf "\n\n----------------\nBuilding $DOCKER_IMAGE\n"
 
 envsubst < setup.Dockerfile > temp
@@ -23,7 +23,7 @@ docker push "$DOCKER_IMAGE"
 ## Build script-runner
 ##
 export USER_UID=1000
-export DOCKER_IMAGE="$DOCKER_REPO/script-runner-alphav1:1.0.0"
+export DOCKER_IMAGE="$DOCKER_REPO/script-runner-alphav2:1.0.0"
 printf "\n\n----------------\nBuilding $DOCKER_IMAGE\n"
 
 envsubst < script.Dockerfile > temp
@@ -58,7 +58,7 @@ for TF_IMAGE in ${AVAILABLE_HASHICORP_TERRAFORM_IMAGES[@]};do
     # (($(docker images hashicorp/terraform:$TF_IMAGE --format='{{ .Repository }}{{ .Tag }}'|wc -l) > 0)) && continue
     export TF_IMAGE
     export USER_UID=1000
-    export DOCKER_IMAGE="$DOCKER_REPO/tf-runner-alphav2:$TF_IMAGE"
+    export DOCKER_IMAGE="$DOCKER_REPO/tf-runner-alphav3:$TF_IMAGE"
     printf "\n\n----------------\nBuilding $DOCKER_IMAGE\n"
 
     envsubst < tf.Dockerfile > temp

--- a/terraform-runner/script.Dockerfile
+++ b/terraform-runner/script.Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/ubuntu:latest
-COPY script.sh /tfo_runner.sh
+COPY script.sh /runner/tfo_runner.sh
 
-ENV TFO_RUNNER_SCRIPT=/tfo_runner.sh \
+ENV TFO_RUNNER_SCRIPT=/runner/tfo_runner.sh \
     USER_UID=1000 \
     USER_NAME=tfo-runner \
     HOME=/home/tfo-runner

--- a/terraform-runner/setup.Dockerfile
+++ b/terraform-runner/setup.Dockerfile
@@ -2,9 +2,9 @@ FROM alpine/git:user
 USER root
 RUN apk add gettext
 COPY backend.tf /backend.tf
-COPY setup.sh /tfo_runner.sh
+COPY setup.sh /runner/tfo_runner.sh
 
-ENV TFO_RUNNER_SCRIPT=/tfo_runner.sh \
+ENV TFO_RUNNER_SCRIPT=/runner/tfo_runner.sh \
     USER_UID=1000 \
     USER_NAME=tfo-runner \
     HOME=/home/tfo-runner

--- a/terraform-runner/tf.Dockerfile
+++ b/terraform-runner/tf.Dockerfile
@@ -1,8 +1,8 @@
 FROM hashicorp/terraform:${TF_IMAGE}
 RUN apk add bash
-COPY tf.sh /tfo_runner.sh
+COPY tf.sh /runner/tfo_runner.sh
 
-ENV TFO_RUNNER_SCRIPT=/tfo_runner.sh \
+ENV TFO_RUNNER_SCRIPT=/runner/tfo_runner.sh \
     USER_UID=1000 \
     USER_NAME=tfo-runner \
     HOME=/home/tfo-runner


### PR DESCRIPTION
Instead of having to update an entire docker image, allow the user to just configure their entrypoint script per runner type. When this option is omitted from the terraform resource, the defaults are used. 