### PR TITLE
fix ssh key setup for runners

### DIFF
--- a/pkg/controllers/terraform_controller.go
+++ b/pkg/controllers/terraform_controller.go
@@ -146,15 +146,15 @@ func newRunOptions(tf *tfv1alpha1.Terraform) RunOptions {
 	// TODO Read the tfstate and decide IF_NEW_RESOURCE based on that
 	// applyAction := false
 	name := tf.Status.PodNamePrefix
-	terraformRunner := "isaaguilar/tf-runner-alphav3"
+	terraformRunner := "isaaguilar/tf-runner-alphav4"
 	terraformRunnerPullPolicy := corev1.PullIfNotPresent
 	terraformVersion := "1.0.2"
 
-	scriptRunner := "isaaguilar/script-runner-alphav2"
+	scriptRunner := "isaaguilar/script-runner-alphav4"
 	scriptRunnerPullPolicy := corev1.PullIfNotPresent
 	scriptRunnerVersion := "1.0.0"
 
-	setupRunner := "isaaguilar/setup-runner-alphav2"
+	setupRunner := "isaaguilar/setup-runner-alphav4"
 	setupRunnerPullPolicy := corev1.PullIfNotPresent
 	setupRunnerVersion := "1.0.0"
 
@@ -2091,8 +2091,8 @@ func (r RunOptions) generatePod(podType, preScriptPodType tfv1alpha1.PodType, is
 
 	// Make sure to use the same uid for containers so the dir in the
 	// PersistentVolume have the correct permissions for the user
-	user := int64(1000)
-	group := int64(1000)
+	user := int64(2000)
+	group := int64(2000)
 	runAsNonRoot := true
 	securityContext := &corev1.SecurityContext{
 		RunAsUser:    &user,

--- a/terraform-runner/build.sh
+++ b/terraform-runner/build.sh
@@ -11,8 +11,8 @@ DOCKER_REPO=${DOCKER_REPO:-"isaaguilar"}
 ##
 ## Build setup-runner
 ##
-export USER_UID=1000
-export DOCKER_IMAGE="$DOCKER_REPO/setup-runner-alphav2:1.0.0"
+export USER_UID=2000
+export DOCKER_IMAGE="$DOCKER_REPO/setup-runner-alphav4:1.0.0"
 printf "\n\n----------------\nBuilding $DOCKER_IMAGE\n"
 
 envsubst < setup.Dockerfile > temp
@@ -22,8 +22,8 @@ docker push "$DOCKER_IMAGE"
 ##
 ## Build script-runner
 ##
-export USER_UID=1000
-export DOCKER_IMAGE="$DOCKER_REPO/script-runner-alphav2:1.0.0"
+export USER_UID=2000
+export DOCKER_IMAGE="$DOCKER_REPO/script-runner-alphav4:1.0.0"
 printf "\n\n----------------\nBuilding $DOCKER_IMAGE\n"
 
 envsubst < script.Dockerfile > temp
@@ -57,8 +57,8 @@ for TF_IMAGE in ${AVAILABLE_HASHICORP_TERRAFORM_IMAGES[@]};do
 
     # (($(docker images hashicorp/terraform:$TF_IMAGE --format='{{ .Repository }}{{ .Tag }}'|wc -l) > 0)) && continue
     export TF_IMAGE
-    export USER_UID=1000
-    export DOCKER_IMAGE="$DOCKER_REPO/tf-runner-alphav3:$TF_IMAGE"
+    export USER_UID=2000
+    export DOCKER_IMAGE="$DOCKER_REPO/tf-runner-alphav4:$TF_IMAGE"
     printf "\n\n----------------\nBuilding $DOCKER_IMAGE\n"
 
     envsubst < tf.Dockerfile > temp

--- a/terraform-runner/script.Dockerfile
+++ b/terraform-runner/script.Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/ubuntu:latest
 COPY script.sh /runner/tfo_runner.sh
 
 ENV TFO_RUNNER_SCRIPT=/runner/tfo_runner.sh \
-    USER_UID=1000 \
+    USER_UID=2000 \
     USER_NAME=tfo-runner \
     HOME=/home/tfo-runner
 COPY usersetup.sh /usersetup.sh

--- a/terraform-runner/setup.Dockerfile
+++ b/terraform-runner/setup.Dockerfile
@@ -5,7 +5,7 @@ COPY backend.tf /backend.tf
 COPY setup.sh /runner/tfo_runner.sh
 
 ENV TFO_RUNNER_SCRIPT=/runner/tfo_runner.sh \
-    USER_UID=1000 \
+    USER_UID=2000 \
     USER_NAME=tfo-runner \
     HOME=/home/tfo-runner
 COPY usersetup.sh /usersetup.sh

--- a/terraform-runner/setup.sh
+++ b/terraform-runner/setup.sh
@@ -1,4 +1,12 @@
 #!/bin/sh -e
+
+# Setup SSH
+mkdir -p "$TFO_ROOT_PATH"/.ssh/
+if stat "$TFO_SSH"/* >/dev/null 2>/dev/null; then
+  cp -Lr "$TFO_SSH"/* "$TFO_ROOT_PATH"/.ssh/
+  chmod -R 0600 "$TFO_ROOT_PATH"/.ssh/*
+fi
+
 if [[ -d "$TFO_MAIN_MODULE" ]]; then
     rm -rf "$TFO_MAIN_MODULE"
 fi
@@ -11,11 +19,6 @@ cp -r "$TFO_MAIN_MODULE_REPO_SUBDIR" "$TFO_MAIN_MODULE"
 # Get configmap and secret files and drop them in the main module's root path
 # Do not overwrite configmap
 false |  cp -iLr "$TFO_DOWNLOADS"/* "$TFO_MAIN_MODULE" 2>/dev/null
-mkdir -p "$TFO_ROOT_PATH"/.ssh/
-if stat "$TFO_SSH"/* >/dev/null 2>/dev/null; then
-  cp -Lr "$TFO_SSH"/* "$TFO_ROOT_PATH"/.ssh/
-  chmod -R 0600 "$TFO_ROOT_PATH"/.ssh/*
-fi
 
 cd "$TFO_MAIN_MODULE"
 

--- a/terraform-runner/tf.Dockerfile
+++ b/terraform-runner/tf.Dockerfile
@@ -3,7 +3,7 @@ RUN apk add bash
 COPY tf.sh /runner/tfo_runner.sh
 
 ENV TFO_RUNNER_SCRIPT=/runner/tfo_runner.sh \
-    USER_UID=1000 \
+    USER_UID=2000 \
     USER_NAME=tfo-runner \
     HOME=/home/tfo-runner
 COPY usersetup.sh /usersetup.sh

--- a/terraform-runner/usersetup.sh
+++ b/terraform-runner/usersetup.sh
@@ -8,7 +8,7 @@ chown ${USER_UID}:0 -R ${HOME}
 chmod ug+rwx ${HOME}
 
 # runtime user will need to be able to self-insert in /etc/passwd
-chmod g+rw /etc/passwd
+chmod 777 /etc/passwd
 
 # no need for this script to remain in the image after running
 rm $0


### PR DESCRIPTION
When using ssh keys, the setup script was not setting up the keys before trying to do a git pull over ssh. Also, the uid was changed to  not conflict with any user that was already defined by the container.  Finally, the /etc/passwd is opened up to add a user by the entrypoint script. 