### PR TITLE
always check a pvc exists

### DIFF
--- a/pkg/controllers/terraform_controller.go
+++ b/pkg/controllers/terraform_controller.go
@@ -2220,10 +2220,8 @@ func (r ReconcileTerraform) run(ctx context.Context, reqLogger logr.Logger, tf *
 	isFirstInstall := tf.Status.Stages[n-1].Reason == "TF_RESOURCE_CREATED"
 
 	if isFirstInstall || isNewGeneration {
-		if isFirstInstall {
-			if err := r.createPVC(ctx, tf, runOpts); err != nil {
-				return err
-			}
+		if err := r.createPVC(ctx, tf, runOpts); err != nil {
+			return err
 		}
 		if err := r.createSecret(ctx, tf, runOpts); err != nil {
 			return err


### PR DESCRIPTION
- always run the `createPVC` function for any resource generation to ensure pods don't get stuck in "persistenvolumeclaim not found". createPVC checks for existing PVC and does not create new ones