### PR TITLE
bump runners

### DIFF
--- a/pkg/controllers/terraform_controller.go
+++ b/pkg/controllers/terraform_controller.go
@@ -171,15 +171,15 @@ func newRunOptions(tf *tfv1alpha1.Terraform) RunOptions {
 	versionedName := name + "-v" + fmt.Sprint(tf.Generation)
 	terraformRunner := "isaaguilar/tf-runner-v5beta1"
 	terraformRunnerPullPolicy := corev1.PullIfNotPresent
-	terraformVersion := "1.1.3"
+	terraformVersion := "1.1.4"
 
 	scriptRunner := "isaaguilar/script-runner"
 	scriptRunnerPullPolicy := corev1.PullIfNotPresent
-	scriptRunnerVersion := "1.0.0"
+	scriptRunnerVersion := "1.0.2"
 
 	setupRunner := "isaaguilar/setup-runner"
 	setupRunnerPullPolicy := corev1.PullIfNotPresent
-	setupRunnerVersion := "1.1.2"
+	setupRunnerVersion := "1.1.3"
 
 	runnerAnnotations := tf.Spec.RunnerAnnotations
 	runnerRules := tf.Spec.RunnerRules

--- a/terraform-runner/build.sh
+++ b/terraform-runner/build.sh
@@ -15,7 +15,7 @@ function cleanup {
 ## Build setup-runner
 ##
 SETUP_RUNNER_IMAGE_NAME="setup-runner"
-SETUP_RUNNER_TAG="1.1.2"
+SETUP_RUNNER_TAG="1.1.3"
 export USER_UID=2000
 export DOCKER_IMAGE="$DOCKER_REPO/$SETUP_RUNNER_IMAGE_NAME:$SETUP_RUNNER_TAG"
 i=0
@@ -143,9 +143,6 @@ BUILT_TF_RUNNER_IMAGES=($(
     done
 ))
 
-pushedfile=/tmp/pushed
-touch $pushedfile
-BUILT_TF_RUNNER_IMAGES=($(cat $pushedfile|tr '\n' ' '))
 for TF_IMAGE in ${AVAILABLE_HASHICORP_TERRAFORM_IMAGES[@]};do
     major=$(cut -d'.' -f1 <<< $TF_IMAGE|sed -E "/^[a-zA-Z+]/d")
     minor=$(cut -d'.' -f2 <<< $TF_IMAGE|sed -E "/^[a-zA-Z+]/d")


### PR DESCRIPTION
Bumped the runners to the latest versions to take advantage of https://github.com/isaaguilar/terraform-operator/pull/73 (ecd7d170f094b61052a0872f1a0ec5ff7d7192dd)

Also I fixed the script to build the tf-runner which prevents rebuilding already pushed images. I accidentally rebuilt: [`1.1.0` `1.1.1` `1.1.2` `1.1.3` `1.1.4`]