### PR TITLE
Failsafe copy module addons

### DIFF
--- a/pkg/controllers/terraform_controller.go
+++ b/pkg/controllers/terraform_controller.go
@@ -171,15 +171,15 @@ func newRunOptions(tf *tfv1alpha1.Terraform) RunOptions {
 	versionedName := name + "-v" + fmt.Sprint(tf.Generation)
 	terraformRunner := "isaaguilar/tf-runner-v5beta1"
 	terraformRunnerPullPolicy := corev1.PullIfNotPresent
-	terraformVersion := "1.1.3"
+	terraformVersion := "1.1.4"
 
 	scriptRunner := "isaaguilar/script-runner"
 	scriptRunnerPullPolicy := corev1.PullIfNotPresent
-	scriptRunnerVersion := "1.0.0"
+	scriptRunnerVersion := "1.0.2"
 
 	setupRunner := "isaaguilar/setup-runner"
 	setupRunnerPullPolicy := corev1.PullIfNotPresent
-	setupRunnerVersion := "1.1.2"
+	setupRunnerVersion := "1.1.3"
 
 	runnerAnnotations := tf.Spec.RunnerAnnotations
 	runnerRules := tf.Spec.RunnerRules

--- a/terraform-runner/build.sh
+++ b/terraform-runner/build.sh
@@ -15,7 +15,7 @@ function cleanup {
 ## Build setup-runner
 ##
 SETUP_RUNNER_IMAGE_NAME="setup-runner"
-SETUP_RUNNER_TAG="1.1.2"
+SETUP_RUNNER_TAG="1.1.3"
 export USER_UID=2000
 export DOCKER_IMAGE="$DOCKER_REPO/$SETUP_RUNNER_IMAGE_NAME:$SETUP_RUNNER_TAG"
 i=0
@@ -143,9 +143,6 @@ BUILT_TF_RUNNER_IMAGES=($(
     done
 ))
 
-pushedfile=/tmp/pushed
-touch $pushedfile
-BUILT_TF_RUNNER_IMAGES=($(cat $pushedfile|tr '\n' ' '))
 for TF_IMAGE in ${AVAILABLE_HASHICORP_TERRAFORM_IMAGES[@]};do
     major=$(cut -d'.' -f1 <<< $TF_IMAGE|sed -E "/^[a-zA-Z+]/d")
     minor=$(cut -d'.' -f2 <<< $TF_IMAGE|sed -E "/^[a-zA-Z+]/d")

--- a/terraform-runner/setup.sh
+++ b/terraform-runner/setup.sh
@@ -96,6 +96,7 @@ function fetch_git {
     relpath="$2"
     files="$3"
     tfvar="$4"
+    branch="$5"
     path="$TFO_MAIN_MODULE/$relpath"
     if [[ "$files" == "." ]] && ( [[ "$relpath" == "." ]] || [[ "$relpath" == "" ]] ); then
     a=$(basename $repo)
@@ -107,6 +108,7 @@ function fetch_git {
     echo "Downloading resources from $repo"
     git clone "$repo" "$temp"
     cd "$temp" # All files are relative to the root of the repo
+    git checkout "$branch"
     # printf -- "cp -r $files $path\n"
     cp -r $files $path
 
@@ -132,7 +134,8 @@ for i in $(seq 0 $((LENGTH - 1))); do
     files=$(jq -r '.files[]' $DATA | join_by "  ")
     path=$(jq -r '.path' $DATA)
     tfvar=$(jq -r '.useAsVar' $DATA)
+    branch=$(jq -r '.hash' $DATA)
     if [[ "$fetchtype" == "git" ]];then
-        fetch_git "$repo" "$path" "$files" "$tfvar"
+        fetch_git "$repo" "$path" "$files" "$tfvar" "$branch"
     fi
 done

--- a/terraform-runner/setup.sh
+++ b/terraform-runner/setup.sh
@@ -59,7 +59,8 @@ fi
 # Will not copy over "hidden" files (files that begin with '.').
 # Do not overwrite configmap
 mkdir -p $TFO_MAIN_MODULE
-false |  cp -iLr "$TFO_MAIN_MODULE_ADDONS"/* "$TFO_MAIN_MODULE" 2>/dev/null
+
+cp -Lr "$TFO_MAIN_MODULE_ADDONS"/* "$TFO_MAIN_MODULE" 2>/dev/null | true
 
 cd "$TFO_MAIN_MODULE"
 


### PR DESCRIPTION
Change the `cp $TFO_MAIN_MODULE_ADDONS` to be failsafe
    
In case of an empty directory `$TFO_MAIN_MODULE_ADDONS` the cp command fails silently.
In this case, the whole setup script ends without an error message.
    
We had that case with an Terraform resource without a customBackend.
    
I'm also not sure about the -i switch to cp, does not make any sense in a script.
