### PR TITLE
In setup-runner, change the cp $TFO_MAIN_MODULE_ADDONS to be failsafe

### DIFF
--- a/terraform-runner/setup.sh
+++ b/terraform-runner/setup.sh
@@ -59,7 +59,8 @@ fi
 # Will not copy over "hidden" files (files that begin with '.').
 # Do not overwrite configmap
 mkdir -p $TFO_MAIN_MODULE
-false |  cp -iLr "$TFO_MAIN_MODULE_ADDONS"/* "$TFO_MAIN_MODULE" 2>/dev/null
+
+cp -Lr "$TFO_MAIN_MODULE_ADDONS"/* "$TFO_MAIN_MODULE" 2>/dev/null | true
 
 cd "$TFO_MAIN_MODULE"
 

--- a/terraform-runner/setup.sh
+++ b/terraform-runner/setup.sh
@@ -59,8 +59,7 @@ fi
 # Will not copy over "hidden" files (files that begin with '.').
 # Do not overwrite configmap
 mkdir -p $TFO_MAIN_MODULE
-
-cp -Lr "$TFO_MAIN_MODULE_ADDONS"/* "$TFO_MAIN_MODULE" 2>/dev/null | true
+false | cp -iLr "$TFO_MAIN_MODULE_ADDONS"/* "$TFO_MAIN_MODULE" 2>/dev/null || true
 
 cd "$TFO_MAIN_MODULE"
 


### PR DESCRIPTION
In case of an empty directory $TFO_MAIN_MODULE_ADDONS the cp command fails silently.
In this case, the whole setup script ends without an error message.

We had that case with an Terraform resource without a customBackend.

I'm also not sure about the -i switch to cp, does not make any sense in a script.