### PR TITLE
allow the export runner to retry on failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ tags
 
 bin
 .builds
+# my release management dir
+.rmgmt

--- a/deploy/crds/tf.isaaguilar.com_terraforms_crd.yaml
+++ b/deploy/crds/tf.isaaguilar.com_terraforms_crd.yaml
@@ -230,6 +230,20 @@ spec:
                     description: ConfFile is the full path relative to the root of
                       the repo
                     type: string
+                  gitEmail:
+                    description: GitEmail is the email of the user who pushes to git.
+                      This email is typically an automation user and probably the
+                      user whose token or sshkey is configured in scmAuthMethod
+                    type: string
+                  gitUsername:
+                    description: GitUsername is the name of the user who pushes to
+                      git. This name is typically an automation user and probably
+                      the user whose token or sshkey is configured in scmAuthMethod
+                    type: string
+                  retryOnFailure:
+                    description: RetryOnFailure sets the export pod's restartPolicy
+                      to "OnFailure"
+                    type: boolean
                   tfvarsFile:
                     description: TFVarsFile is the full path relative to the root
                       of the repo

--- a/pkg/apis/tf/v1alpha1/terraform_types.go
+++ b/pkg/apis/tf/v1alpha1/terraform_types.go
@@ -249,6 +249,19 @@ type ExportRepo struct {
 
 	// ConfFile is the full path relative to the root of the repo
 	ConfFile string `json:"confFile,omitempty"`
+
+	// GitEmail is the email of the user who pushes to git. This email is
+	// typically an automation user and probably the user whose token or sshkey
+	// is configured in scmAuthMethod
+	GitEmail string `json:"gitEmail,omitempty"`
+
+	// GitUsername is the name of the user who pushes to git. This name is
+	// typically an automation user and probably the user whose token or sshkey
+	// is configured in scmAuthMethod
+	GitUsername string `json:"gitUsername,omitempty"`
+
+	// RetryOnFailure sets the export pod's restartPolicy to "OnFailure"
+	RetryOnFailure bool `json:"retryOnFailure,omitempty"`
 }
 
 // ReconcileTerraformDeployment is used to configure auto watching the resources


### PR DESCRIPTION
Sometimes export Runner fails when the target repo is updated after the runner has downloaded the repo and before it pushes changes. This results in the target being ahead of the export runner and the git command fails to push to the repo.  When a lot of TFO resources run at the same time, and they all want to use export repo, this tends to happen a lot. To fix this, allow the export runner to retry on failure. If true the pod restarts and the push attempt will be repeated.

Also allow the user to define the email and username of the automation user that pushes to git.
Configure as:

```yaml
kind: Terraform
spec:
    ...
    exportRepo:
        ...
        retryOnFailure: true
        gitUsername: automation user1
        gitEmail: autogit@company.com
```