### PR TITLE
added a runner labels option

### DIFF
--- a/deploy/crds/tf.isaaguilar.com_terraforms_crd.yaml
+++ b/deploy/crds/tf.isaaguilar.com_terraforms_crd.yaml
@@ -375,6 +375,12 @@ spec:
                 description: RunnerAnnotations are annotations that will be added
                   to all runner pods.
                 type: object
+              runnerLabels:
+                additionalProperties:
+                  type: string
+                description: RunnerLabels key/value pairs that will be added as labels
+                  to runner pods
+                type: object
               runnerRules:
                 description: RunnerRules are RBAC rules that will be added to all
                   runner pods.

--- a/pkg/apis/tf/v1alpha1/terraform_types.go
+++ b/pkg/apis/tf/v1alpha1/terraform_types.go
@@ -51,6 +51,9 @@ type TerraformSpec struct {
 	// RunnerAnnotations are annotations that will be added to all runner pods.
 	RunnerAnnotations map[string]string `json:"runnerAnnotations,omitempty"`
 
+	// RunnerLabels key/value pairs that will be added as labels to runner pods
+	RunnerLabels map[string]string `json:"runnerLabels,omitempty"`
+
 	// TerraformVersion helps the operator decide which image tag to pull for
 	// the terraform runner. Defaults to "0.11.14"
 	TerraformVersion    string `json:"terraformVersion,omitempty"`

--- a/pkg/apis/tf/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/tf/v1alpha1/zz_generated.deepcopy.go
@@ -376,6 +376,13 @@ func (in *TerraformSpec) DeepCopyInto(out *TerraformSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.RunnerLabels != nil {
+		in, out := &in.RunnerLabels, &out.RunnerLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.TerraformRunnerExecutionScriptConfigMap != nil {
 		in, out := &in.TerraformRunnerExecutionScriptConfigMap, &out.TerraformRunnerExecutionScriptConfigMap
 		*out = new(corev1.ConfigMapKeySelector)

--- a/pkg/apis/tf/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/tf/v1alpha1/zz_generated.openapi.go
@@ -139,6 +139,22 @@ func schema_pkg_apis_tf_v1alpha1_TerraformSpec(ref common.ReferenceCallback) com
 							},
 						},
 					},
+					"runnerLabels": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RunnerLabels key/value pairs that will be added as labels to runner pods",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 					"terraformVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TerraformVersion helps the operator decide which image tag to pull for the terraform runner. Defaults to \"0.11.14\"",

--- a/pkg/controllers/terraform_controller.go
+++ b/pkg/controllers/terraform_controller.go
@@ -167,6 +167,7 @@ type RunOptions struct {
 	saveOutputs                             bool
 	outputsToInclude                        []string
 	outputsToOmit                           []string
+	runnerLabels                            map[string]string
 }
 
 func newRunOptions(tf *tfv1alpha1.Terraform) RunOptions {
@@ -246,6 +247,10 @@ func newRunOptions(tf *tfv1alpha1.Terraform) RunOptions {
 		cleanupDisk: tf.Spec.CleanupDisk,
 	}
 
+	runnerLabels := make(map[string]string)
+	if len(tf.Spec.RunnerLabels) > 0 {
+		runnerLabels = tf.Spec.RunnerLabels
+	}
 	return RunOptions{
 		namespace:                               tf.Namespace,
 		tfName:                                  tfName,
@@ -275,6 +280,7 @@ func newRunOptions(tf *tfv1alpha1.Terraform) RunOptions {
 		saveOutputs:                             saveOutputs,
 		outputsToInclude:                        outputsToInclude,
 		outputsToOmit:                           outputsToOmit,
+		runnerLabels:                            runnerLabels,
 	}
 }
 
@@ -1929,7 +1935,7 @@ func (r RunOptions) generatePod(podType, preScriptPodType tfv1alpha1.PodType, is
 		}
 	}
 
-	labels := make(map[string]string)
+	labels := r.runnerLabels
 	labels["terraforms.tf.isaaguilar.com/generation"] = fmt.Sprintf("%d", generation)
 	labels["terraforms.tf.isaaguilar.com/resourceName"] = r.tfName
 	labels["terraforms.tf.isaaguilar.com/podPrefix"] = r.name


### PR DESCRIPTION
Fixes #86  Added the ability to add extra labels to runner pods. Example:

```yaml
kind: Terraform
spec:
  ...
  runnerLabels:
    aadpodidbinding: my-azure-identity-binding
```