### PR TITLE
update tf runner and setup runners

### DIFF
--- a/pkg/controllers/terraform_controller.go
+++ b/pkg/controllers/terraform_controller.go
@@ -176,9 +176,9 @@ func newRunOptions(tf *tfv1alpha1.Terraform) RunOptions {
 	tfName := tf.Name
 	name := tf.Status.PodNamePrefix
 	versionedName := name + "-v" + fmt.Sprint(tf.Generation)
-	terraformRunner := "isaaguilar/tf-runner-v5beta1"
+	terraformRunner := "isaaguilar/tf-runner-v5beta2"
 	terraformRunnerPullPolicy := corev1.PullIfNotPresent
-	terraformVersion := "1.1.5"
+	terraformVersion := "1.1.9"
 
 	scriptRunner := "isaaguilar/script-runner"
 	scriptRunnerPullPolicy := corev1.PullIfNotPresent
@@ -186,7 +186,7 @@ func newRunOptions(tf *tfv1alpha1.Terraform) RunOptions {
 
 	setupRunner := "isaaguilar/setup-runner"
 	setupRunnerPullPolicy := corev1.PullIfNotPresent
-	setupRunnerVersion := "1.1.6"
+	setupRunnerVersion := "1.1.7"
 
 	runnerAnnotations := tf.Spec.RunnerAnnotations
 	runnerRules := tf.Spec.RunnerRules

--- a/terraform-runner/build.sh
+++ b/terraform-runner/build.sh
@@ -15,7 +15,7 @@ function cleanup {
 ## Build setup-runner
 ##
 SETUP_RUNNER_IMAGE_NAME="setup-runner"
-SETUP_RUNNER_TAG="1.1.6"
+SETUP_RUNNER_TAG="1.1.7"
 export USER_UID=2000
 export DOCKER_IMAGE="$DOCKER_REPO/$SETUP_RUNNER_IMAGE_NAME:$SETUP_RUNNER_TAG"
 i=0
@@ -175,7 +175,7 @@ done
 ##
 ## Build tf-runner(s)
 ##
-TF_RUNNER_IMAGE_NAME="tf-runner-v5beta1"
+TF_RUNNER_IMAGE_NAME="tf-runner-v5beta2"
 printf "\n\n----------------\nFetching available hashicorp/terraform versions"
 i=0
 BUILT_TF_RUNNER_IMAGES=($(

--- a/terraform-runner/setup-arm64.Dockerfile
+++ b/terraform-runner/setup-arm64.Dockerfile
@@ -1,8 +1,8 @@
 # FROM alpine/k8s:1.20.7 as k8s
 FROM docker.io/library/debian@sha256:e3bb8517d8dd28c789f3e8284d42bd8019c05b17d851a63df09fd9230673306f as k8s
 RUN apt update -y && apt install curl -y
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-RUN curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
+RUN curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl.sha256"
 RUN ls -lah kubectl
 RUN ls -lah kubectl.sha256
 RUN echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check

--- a/terraform-runner/tf-arm64.Dockerfile
+++ b/terraform-runner/tf-arm64.Dockerfile
@@ -2,17 +2,30 @@ FROM isaaguilar/terraform-arm64:${TF_IMAGE} as terraform
 
 FROM docker.io/library/debian@sha256:e3bb8517d8dd28c789f3e8284d42bd8019c05b17d851a63df09fd9230673306f as k8s
 RUN apt update -y && apt install curl -y
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-RUN curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
+RUN curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl.sha256"
 RUN ls -lah kubectl
 RUN ls -lah kubectl.sha256
 RUN echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
 RUN install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
+FROM ubuntu:20.04 as irsa-tokengen
+WORKDIR /workdir
+RUN mkdir bin
+RUN apt update && apt install wget -y
+RUN wget https://github.com/isaaguilar/irsa-tokengen/releases/download/v1.0.0/irsa-tokengen-v1.0.0-linux-arm64.tgz && \
+    tar xzf irsa-tokengen-v1.0.0-linux-arm64.tgz && mv irsa-tokengen bin/irsa-tokengen
+
+FROM ubuntu:latest as bin
+WORKDIR /workdir
+RUN mkdir bin
+COPY --from=terraform /usr/local/bin/terraform bin/terraform
+COPY --from=k8s /usr/local/bin/kubectl bin/kubectl
+COPY --from=irsa-tokengen /workdir/bin/irsa-tokengen bin/irsa-tokengen
+
 FROM docker.io/library/alpine@sha256:c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060
-RUN apk add bash jq
-COPY --from=terraform /usr/local/bin/terraform /usr/local/bin/terraform
-COPY --from=k8s /usr/local/bin/kubectl /usr/local/bin/kubectl
+RUN apk add bash jq git
+COPY --from=bin /workdir/bin /usr/local/bin
 COPY tf.sh /runner/tfo_runner.sh
 
 ENV TFO_RUNNER_SCRIPT=/runner/tfo_runner.sh \

--- a/terraform-runner/tf.Dockerfile
+++ b/terraform-runner/tf.Dockerfile
@@ -1,8 +1,21 @@
 FROM alpine/k8s:1.20.7 as k8s
 
+FROM ubuntu:20.04 as irsa-tokengen
+WORKDIR /workdir
+RUN mkdir bin
+RUN apt update && apt install wget -y
+RUN wget https://github.com/isaaguilar/irsa-tokengen/releases/download/v1.0.0/irsa-tokengen-v1.0.0-linux-amd64.tgz && \
+    tar xzf irsa-tokengen-v1.0.0-linux-amd64.tgz && mv irsa-tokengen bin/irsa-tokengen
+
+FROM ubuntu:latest as bin
+WORKDIR /workdir
+RUN mkdir bin
+COPY --from=k8s /usr/bin/kubectl bin/kubectl
+COPY --from=irsa-tokengen /workdir/bin/irsa-tokengen bin/irsa-tokengen
+
 FROM hashicorp/terraform:${TF_IMAGE}
 RUN apk add bash jq
-COPY --from=k8s /usr/bin/kubectl /usr/local/bin/kubectl
+COPY --from=bin /workdir/bin /usr/local/bin
 COPY tf.sh /runner/tfo_runner.sh
 
 ENV TFO_RUNNER_SCRIPT=/runner/tfo_runner.sh \


### PR DESCRIPTION

- updated terraformRunner's `tf.sh` for IRSA support by hacking irsa creds as static AWS_ACCESS_KEY_ID creds
- fixed the arm64 binaries for kubectl in setupRunner and terraformRunner (fixes #71)
- fixed missing git binary for arm64 in terraformRunner (fixes #71)