### PR TITLE
added `keepLatestPodsOnly` to the tf spec

### DIFF
--- a/deploy/crds/tf.isaaguilar.com_terraforms_crd.yaml
+++ b/deploy/crds/tf.isaaguilar.com_terraforms_crd.yaml
@@ -260,6 +260,11 @@ spec:
                 description: KeepCompletedPods when true will keep completed pods.
                   Default is false and completed pods are removed.
                 type: boolean
+              keepLatestPodsOnly:
+                description: KeepLatestPodsOnly when true will keep only the pods
+                  that match the current generation of the terraform k8s-resource.
+                  This overrides the behavior of `keepCompletedPods`.
+                type: boolean
               outputsSecret:
                 description: OutputsSecret will create a secret with the outputs from
                   the module. All outputs from the module will be written to the secret

--- a/pkg/apis/tf/v1alpha1/terraform_types.go
+++ b/pkg/apis/tf/v1alpha1/terraform_types.go
@@ -33,6 +33,11 @@ type TerraformSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 
+	// KeepLatestPodsOnly when true will keep only the pods that match the
+	// current generation of the terraform k8s-resource. This overrides the
+	// behavior of `keepCompletedPods`.
+	KeepLatestPodsOnly bool `json:"keepLatestPodsOnly,omitempty"`
+
 	// KeepCompletedPods when true will keep completed pods. Default is false
 	// and completed pods are removed.
 	KeepCompletedPods bool `json:"keepCompletedPods,omitempty"`

--- a/pkg/apis/tf/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/tf/v1alpha1/zz_generated.openapi.go
@@ -90,6 +90,13 @@ func schema_pkg_apis_tf_v1alpha1_TerraformSpec(ref common.ReferenceCallback) com
 				Description: "TerraformSpec defines the desired state of Terraform",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"keepLatestPodsOnly": {
+						SchemaProps: spec.SchemaProps{
+							Description: "KeepLatestPodsOnly when true will keep only the pods that match the current generation of the terraform k8s-resource. This overrides the behavior of `keepCompletedPods`.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"keepCompletedPods": {
 						SchemaProps: spec.SchemaProps{
 							Description: "KeepCompletedPods when true will keep completed pods. Default is false and completed pods are removed.",


### PR DESCRIPTION
fixes #94

- added `keepLatestPodsOnly` to the terraform spec which will only keep the current tf k8s-resource generation's pods.

**example**

```yaml
kind: Terraform
spec:
  ...
  keepLatestPodsOnly: true
```