### PR TITLE
remove newlines from outputs

### DIFF
--- a/pkg/controllers/terraform_controller.go
+++ b/pkg/controllers/terraform_controller.go
@@ -178,7 +178,7 @@ func newRunOptions(tf *tfv1alpha1.Terraform) RunOptions {
 	tfName := tf.Name
 	name := tf.Status.PodNamePrefix
 	versionedName := name + "-v" + fmt.Sprint(tf.Generation)
-	terraformRunner := "isaaguilar/tf-runner-v5beta3"
+	terraformRunner := "isaaguilar/tf-runner-v5beta4"
 	terraformRunnerPullPolicy := corev1.PullIfNotPresent
 	terraformVersion := "1.1.9"
 

--- a/terraform-runner/build.sh
+++ b/terraform-runner/build.sh
@@ -175,7 +175,7 @@ done
 ##
 ## Build tf-runner(s)
 ##
-TF_RUNNER_IMAGE_NAME="tf-runner-v5beta3"
+TF_RUNNER_IMAGE_NAME="tf-runner-v5beta4"
 printf "\n\n----------------\nFetching available hashicorp/terraform versions"
 i=0
 BUILT_TF_RUNNER_IMAGES=($(

--- a/terraform-runner/tf.sh
+++ b/terraform-runner/tf.sh
@@ -79,7 +79,7 @@ if [[ "$TFO_RUNNER" == "apply" ]] && [[ "$TFO_SAVE_OUTPUTS" == "true" ]]; then
       echo "Omitting $key"
       continue
     fi
-    b64value=$(jq -r --arg key $key '.[$key].value' <<< $jsonoutput|base64|tr -d '[:space:]')
+    b64value=$(jq -j --arg key $key '.[$key].value' <<< $jsonoutput|base64|tr -d '[:space:]')
     jq -Mc --arg key $key --arg value $b64value '. += [
       {"op":"add","path":"/data/\($key)","value":"\($value)"}
     ]' "$data" > "$t"


### PR DESCRIPTION
`jq` adds a newline when using the `-r` flag. Switched to the `-j` flag which removes the newline.