### PR TITLE
Preserve outputsSecret Secret on generation changes

### DIFF
--- a/hack/devbuild.sh
+++ b/hack/devbuild.sh
@@ -11,14 +11,20 @@ gitshort=$(git rev-list HEAD --abbrev-commit --max-count 1)
 repo="isaaguilar/$PROJECT"
 
 LATEST_TAG="v0.0.0" # default for new projects or a fallback in case logic breaks
+if [[ -z "$DESIRED_VERSION" ]]; then
 if git tag --sort=version:refname --sort=-creatordate | head -n1; then
 LATEST_TAG=$(git tag --sort=version:refname --sort=-creatordate | head -n1)
 fi
+fi
 
-CURRENT_VERSION=${LATEST_TAG}
+# Dev builds are usually for a new version that has not been tagged yet.
+# In order to make this easy, allow an environment var to define the desired
+# version.
+CURRENT_VERSION=${DESIRED_VERSION:-LATEST_TAG}
 if [[ "$CURRENT_VERSION" != "v"* ]]; then
 exit 1
 fi
+
 CURRENT_VERSION=${CURRENT_VERSION#v}
 CURRENT_VERSION=${CURRENT_VERSION%-*}
 major=$(echo $CURRENT_VERSION|cut -d'.' -f1)


### PR DESCRIPTION
fixes #107 

- Changed the deletion of older generation resources to ensure that that following are try before deleting the resouce:
  1. The `terraforms.tf.isaaguilar.com/generation` key MUST exist
  2. The `terraforms.tf.isaaguilar.com/generation` value MUST match the current resource generation
  3. The `terraforms.tf.isaaguilar.com/resourceName` key MUST exist
  4. The `terraforms.tf.isaaguilar.com/resourceName` value MUST match the resource name
- Stripped the `terraforms.tf.isaaguilar.com/generation` label from the outputsSecret when `spec.outputsSecret` is a defined value.