### PR TITLE
update tftask image for arm 64 fix

### DIFF
--- a/pkg/apis/tf/v1alpha2/terraform_types.go
+++ b/pkg/apis/tf/v1alpha2/terraform_types.go
@@ -11,7 +11,7 @@ import (
 const (
 	SetupTaskImageRepoDefault     = "ghcr.io/galleybytes/terraform-operator-setup"
 	SetupTaskImageTagDefault      = "1.0.1"
-	TerraformTaskImageRepoDefault = "ghcr.io/galleybytes/terraform-operator-tftaskv1"
+	TerraformTaskImageRepoDefault = "ghcr.io/galleybytes/terraform-operator-tftaskv1.0.1"
 	TerraformTaskImageTagDefault  = ""
 	ScriptTaskImageRepoDefault    = "ghcr.io/galleybytes/terraform-operator-script"
 	ScriptTaskImageTagDefault     = "1.0.1"


### PR DESCRIPTION
Change default tftask image, tftaskv1.0.1:
- https://github.com/GalleyBytes/terraform-operator-tasks/blob/master/images/tftaskv1.0.1-amd64.Dockerfile
- https://github.com/GalleyBytes/terraform-operator-tasks/blob/master/images/tftaskv1.0.1-arm64v8.Dockerfile