### PR TITLE
Fix issue with default outputs secret lifecycle

### DIFF
--- a/pkg/controllers/terraform_controller.go
+++ b/pkg/controllers/terraform_controller.go
@@ -425,7 +425,7 @@ func newTaskOptions(tf *tfv1alpha2.Terraform, task tfv1alpha2.TaskName, generati
 
 	// Outputs will be saved as a secret that will have the same lifecycle
 	// as the Terraform CustomResource by adding the ownership metadata
-	outputsSecretName := prefixedName + "-outputs"
+	outputsSecretName := versionedName + "-outputs"
 	saveOutputs := false
 	stripGenerationLabelOnOutputsSecret := false
 	if tf.Spec.OutputsSecret != "" {


### PR DESCRIPTION
The default behavior of outputs secrets is to be generational and to have the same lifecycle as other generational resources. However, the name of the secret was not generational and would be removed by the generation cleanup job. Cleanup happens after create, which means the secret that was required was removed. This caused issues for scripts needing the secret to exist.

To solve this problem, the secret name is now also generational. This means that each generation will have a new secret that will not be deleted until the generation is no longer current.