### PR TITLE
added gitSecret locks

### DIFF
--- a/deploy/crds/tf.galleybytes.com_terraforms_crd.yaml
+++ b/deploy/crds/tf.galleybytes.com_terraforms_crd.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
   name: terraforms.tf.galleybytes.com
 spec:
   group: tf.galleybytes.com
@@ -287,6 +288,10 @@ spec:
                                 key:
                                   description: Key in the secret ref. Default to `token`
                                   type: string
+                                lockSecretDeletion:
+                                  description: Set finalizer from controller on the
+                                    secret
+                                  type: boolean
                                 name:
                                   description: Name the secret name that has the token
                                     or password
@@ -314,6 +319,10 @@ spec:
                                 key:
                                   description: Key in the secret ref. Default to `id_rsa`
                                   type: string
+                                lockSecretDeletion:
+                                  description: Set finalizer from controller on the
+                                    secret
+                                  type: boolean
                                 name:
                                   description: Name the secret name that has the SSH
                                     key
@@ -392,6 +401,9 @@ spec:
                       key:
                         description: Key in the secret ref. Default to `id_rsa`
                         type: string
+                      lockSecretDeletion:
+                        description: Set finalizer from controller on the secret
+                        type: boolean
                       name:
                         description: Name the secret name that has the SSH key
                         type: string

--- a/deploy/crds/tf.galleybytes.com_terraforms_crd.yaml
+++ b/deploy/crds/tf.galleybytes.com_terraforms_crd.yaml
@@ -290,7 +290,8 @@ spec:
                                   type: string
                                 lockSecretDeletion:
                                   description: Set finalizer from controller on the
-                                    secret
+                                    secret to prevent delete flow breaking Works only
+                                    with spec.ignoreDelete = true
                                   type: boolean
                                 name:
                                   description: Name the secret name that has the token
@@ -321,7 +322,8 @@ spec:
                                   type: string
                                 lockSecretDeletion:
                                   description: Set finalizer from controller on the
-                                    secret
+                                    secret to prevent delete flow breaking Works only
+                                    with spec.ignoreDelete = true
                                   type: boolean
                                 name:
                                   description: Name the secret name that has the SSH
@@ -402,7 +404,9 @@ spec:
                         description: Key in the secret ref. Default to `id_rsa`
                         type: string
                       lockSecretDeletion:
-                        description: Set finalizer from controller on the secret
+                        description: Set finalizer from controller on the secret to
+                          prevent delete flow breaking Works only with spec.ignoreDelete
+                          = true
                         type: boolean
                       name:
                         description: Name the secret name that has the SSH key

--- a/pkg/apis/tf/v1beta1/terraform_types.go
+++ b/pkg/apis/tf/v1beta1/terraform_types.go
@@ -518,6 +518,9 @@ type SSHKeySecretRef struct {
 	Namespace string `json:"namespace,omitempty"`
 	// Key in the secret ref. Default to `id_rsa`
 	Key string `json:"key,omitempty"`
+	// Set finalizer from controller on the secret to prevent delete flow breaking
+	// Works only with spec.ignoreDelete = true
+	LockSecretDeletion bool `json:"lockSecretDeletion,omitempty"`
 }
 
 // TokenSecretRef defines the token or password that can be used to log into a system (eg git)
@@ -529,6 +532,9 @@ type TokenSecretRef struct {
 	Namespace string `json:"namespace,omitempty"`
 	// Key in the secret ref. Default to `token`
 	Key string `json:"key,omitempty"`
+	// Set finalizer from controller on the secret to prevent delete flow breaking
+	// Works only with spec.ignoreDelete = true
+	LockSecretDeletion bool `json:"lockSecretDeletion,omitempty"`
 }
 
 // Credentials are used for adding credentials for terraform providers.

--- a/pkg/apis/tf/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/tf/v1beta1/zz_generated.openapi.go
@@ -511,6 +511,13 @@ func schema_pkg_apis_tf_v1beta1_SSHKeySecretRef(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
+					"lockSecretDeletion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Set finalizer from controller on the secret to prevent delete flow breaking Works only with spec.ignoreDelete = true",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"name"},
 			},
@@ -1204,6 +1211,13 @@ func schema_pkg_apis_tf_v1beta1_TokenSecretRef(ref common.ReferenceCallback) com
 						SchemaProps: spec.SchemaProps{
 							Description: "Key in the secret ref. Default to `token`",
 							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"lockSecretDeletion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Set finalizer from controller on the secret to prevent delete flow breaking Works only with spec.ignoreDelete = true",
+							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},

--- a/pkg/controllers/terraform_controller.go
+++ b/pkg/controllers/terraform_controller.go
@@ -1441,7 +1441,7 @@ func (r ReconcileTerraform) getGitSecrets(tf *tfv1beta1.Terraform) []gitSecret {
 func (r ReconcileTerraform) updateSecretFinalizer(ctx context.Context, tf *tfv1beta1.Terraform) error {
 	secrets := r.getGitSecrets(tf)
 	for _, m := range secrets {
-		if m.shoudBeLocked {
+		if m.shoudBeLocked && tf.Status.Phase != tfv1beta1.PhaseDeleted {
 			if err := r.lockGitSecretDeletion(ctx, m.name, m.namespace); err != nil {
 				return err
 			}


### PR DESCRIPTION
Added ability to lock k8s secrets referred in SCMAuthMethods error via controller's finalizer. It prevents terraform workflow from failing when secret(s) were deleted before setup/init-delete jobs have been fully completed. 