### PR TITLE
add sync label/annotation for use with tfoapi

### DIFF
--- a/pkg/apis/tf/v1beta1/terraform_types.go
+++ b/pkg/apis/tf/v1beta1/terraform_types.go
@@ -1,6 +1,8 @@
 package v1beta1
 
 import (
+	"encoding/json"
+
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -751,6 +753,73 @@ const (
 	CanNotBeInterrupt Interruptible = false
 	CanBeInterrupt    Interruptible = true
 )
+
+// This function implements the Marshaler interface for boolean values. It always returns a JSON representation
+// of the boolean value, even if it is false. This is different from the default json package, which omits false
+// values when marshalling. This behavior is useful for sending JSON data over HTTP, where false values need to
+// be explicitly included to avoid being ignored in patches.
+func (s TerraformSpec) MarshalJSON() ([]byte, error) {
+	type Alias TerraformSpec
+	return json.Marshal(&struct {
+		*Alias
+		KeepLatestPodsOnly   bool `json:"keepLatestPodsOnly"`
+		KeepCompletedPods    bool `json:"keepCompletedPods"`
+		WriteOutputsToStatus bool `json:"writeOutputsToStatus"`
+		IgnoreDelete         bool `json:"ignoreDelete"`
+		RequireApproval      bool `json:"requireApproval"`
+	}{
+		Alias:                (*Alias)(&s),
+		KeepLatestPodsOnly:   s.KeepLatestPodsOnly,
+		KeepCompletedPods:    s.KeepCompletedPods,
+		WriteOutputsToStatus: s.WriteOutputsToStatus,
+		IgnoreDelete:         s.IgnoreDelete,
+		RequireApproval:      s.RequireApproval,
+	})
+}
+
+func (s Setup) MarshalJSON() ([]byte, error) {
+	type Alias Setup
+	return json.Marshal(&struct {
+		*Alias
+		CleanupDisk bool `json:"cleanupDisk"`
+	}{
+		Alias:       (*Alias)(&s),
+		CleanupDisk: s.CleanupDisk,
+	})
+}
+
+func (s GitSSH) MarshalJSON() ([]byte, error) {
+	type Alias GitSSH
+	return json.Marshal(&struct {
+		*Alias
+		RequireProxy bool `json:"requireProxy"`
+	}{
+		Alias:        (*Alias)(&s),
+		RequireProxy: s.RequireProxy,
+	})
+}
+
+func (s GitHTTPS) MarshalJSON() ([]byte, error) {
+	type Alias GitHTTPS
+	return json.Marshal(&struct {
+		*Alias
+		RequireProxy bool `json:"requireProxy"`
+	}{
+		Alias:        (*Alias)(&s),
+		RequireProxy: s.RequireProxy,
+	})
+}
+
+func (s ResourceDownload) MarshalJSON() ([]byte, error) {
+	type Alias ResourceDownload
+	return json.Marshal(&struct {
+		*Alias
+		UseAsVar bool `json:"useAsVar"`
+	}{
+		Alias:    (*Alias)(&s),
+		UseAsVar: s.UseAsVar,
+	})
+}
 
 func init() {
 	SchemeBuilder.Register(&Terraform{}, &TerraformList{})

--- a/pkg/controllers/terraform_controller.go
+++ b/pkg/controllers/terraform_controller.go
@@ -1819,6 +1819,7 @@ func (r ReconcileTerraform) createSecret(ctx context.Context, tf *tfv1beta1.Terr
 	for key, value := range runOpts.resourceLabels {
 		labels[key] = value
 	}
+	labels["tfo-api.galleybytes.com/sync"] = "1"
 	for _, labelKey := range labelsToOmit {
 		delete(labels, labelKey)
 	}
@@ -2582,7 +2583,7 @@ func (r ReconcileTerraform) run(ctx context.Context, reqLogger logr.Logger, tf *
 			return err
 		}
 
-		if err := r.createSecret(ctx, tf, runOpts.versionedName, runOpts.namespace, runOpts.secretData, true, []string{}, runOpts); err != nil {
+		if err := r.createSecret(ctx, tf, runOpts.versionedName, runOpts.namespace, runOpts.secretData, true, []string{"tfo-api.galleybytes.com/sync"}, runOpts); err != nil {
 			return err
 		}
 
@@ -2799,11 +2800,17 @@ func (r ReconcileTerraform) cacheNodeSelectors(ctx context.Context, logger logr.
 }
 
 func (r TaskOptions) generateSecret(name, namespace string, data map[string][]byte, labels map[string]string) *corev1.Secret {
+	annotations := map[string]string{}
+
+	if _, found := labels["tfo-api.galleybytes.com/sync"]; found {
+		annotations["tfo-api.galleybytes.com/sync-upon-completion-of"] = "- " + r.resourceName
+	}
 	secretObject := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    labels,
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Data: data,
 		Type: corev1.SecretTypeOpaque,


### PR DESCRIPTION
syncs labeled resources between tfo-remote-controller and tfo-api.