### PR TITLE
move secret finalizer check

### DIFF
--- a/pkg/apis/tf/v1beta1/terraform_types.go
+++ b/pkg/apis/tf/v1beta1/terraform_types.go
@@ -520,8 +520,8 @@ type SSHKeySecretRef struct {
 	Namespace string `json:"namespace,omitempty"`
 	// Key in the secret ref. Default to `id_rsa`
 	Key string `json:"key,omitempty"`
-	// Set finalizer from controller on the secret to prevent delete flow breaking
-	// Works only with spec.ignoreDelete = true
+	// Set finalizer from controller on the secret to prevent delete flow breaking.
+	// Works only with `spec.ignoreDelete = true`.
 	LockSecretDeletion bool `json:"lockSecretDeletion,omitempty"`
 }
 


### PR DESCRIPTION
The new secret lock finalizer as getting called too often having to check secrets on every reconcile loop. Instead, move the finalizer check to be run once per generation change and upon final removal.

- changed the default finalizer name back to the original name to ensure resources created on stables versions will continue to finalize correctly
- added a new finalizer name that is unique per tf resource