### PR TITLE
Change label value to hash sum if > 63 chars

### DIFF
--- a/pkg/controllers/terraform_controller.go
+++ b/pkg/controllers/terraform_controller.go
@@ -491,7 +491,7 @@ func newTaskOptions(tf *tfv1beta1.Terraform, task tfv1beta1.TaskName, generation
 
 	resourceLabels := map[string]string{
 		"terraforms.tf.galleybytes.com/generation":       fmt.Sprintf("%d", generation),
-		"terraforms.tf.galleybytes.com/resourceName":     resourceName,
+		"terraforms.tf.galleybytes.com/resourceName":     utils.AutoHashLabeler(resourceName),
 		"terraforms.tf.galleybytes.com/podPrefix":        prefixedName,
 		"terraforms.tf.galleybytes.com/terraformVersion": terraformVersion,
 		"app.kubernetes.io/name":                         "terraform-operator",
@@ -1179,9 +1179,10 @@ func (r ReconcileTerraform) checkSetNewStage(ctx context.Context, tf *tfv1beta1.
 }
 
 func (r ReconcileTerraform) removeOldPlan(namespace, name, reason string, generation int64) error {
+
 	labelSelectors := []string{
 		fmt.Sprintf("terraforms.tf.galleybytes.com/generation==%d", generation),
-		fmt.Sprintf("terraforms.tf.galleybytes.com/resourceName=%s", name),
+		fmt.Sprintf("terraforms.tf.galleybytes.com/resourceName=%s", utils.AutoHashLabeler(name)),
 		"app.kubernetes.io/instance",
 	}
 	if reason == "RESTARTED_WORKFLOW" {
@@ -1319,7 +1320,7 @@ func (r ReconcileTerraform) backgroundReapOldGenerationPods(tf *tfv1beta1.Terraf
 	// 2. The terraforms.tf.galleybytes.com/generation value MUST match the current resource generation
 	// 3. The terraforms.tf.galleybytes.com/resourceName key MUST exist
 	// 4. The terraforms.tf.galleybytes.com/resourceName value MUST match the resource name
-	labelSelector, err := labels.Parse(fmt.Sprintf("terraforms.tf.galleybytes.com/generation,terraforms.tf.galleybytes.com/generation!=%d,terraforms.tf.galleybytes.com/resourceName,terraforms.tf.galleybytes.com/resourceName=%s", tf.Generation, tf.Name))
+	labelSelector, err := labels.Parse(fmt.Sprintf("terraforms.tf.galleybytes.com/generation,terraforms.tf.galleybytes.com/generation!=%d,terraforms.tf.galleybytes.com/resourceName,terraforms.tf.galleybytes.com/resourceName=%s", tf.Generation, utils.AutoHashLabeler(tf.Name)))
 	if err != nil {
 		logger.Error(err, "Could not parse labels")
 		return
@@ -1442,7 +1443,7 @@ func (r ReconcileTerraform) reapPlugins(tf *tfv1beta1.Terraform, attempt int) {
 	}
 
 	// Delete old plugins regardless of pod phase
-	labelSelectorForPlugins, err := labels.Parse(fmt.Sprintf("terraforms.tf.galleybytes.com/isPlugin=true,terraforms.tf.galleybytes.com/generation,terraforms.tf.galleybytes.com/generation!=%d,terraforms.tf.galleybytes.com/resourceName,terraforms.tf.galleybytes.com/resourceName=%s", tf.Generation, tf.Name))
+	labelSelectorForPlugins, err := labels.Parse(fmt.Sprintf("terraforms.tf.galleybytes.com/isPlugin=true,terraforms.tf.galleybytes.com/generation,terraforms.tf.galleybytes.com/generation!=%d,terraforms.tf.galleybytes.com/resourceName,terraforms.tf.galleybytes.com/resourceName=%s", tf.Generation, utils.AutoHashLabeler(tf.Name)))
 	if err != nil {
 		logger.Error(err, "Could not parse labels")
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"bytes"
+	"crypto/md5"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -162,6 +164,15 @@ func TruncateResourceName(s string, i int) string {
 		name = strings.TrimRight(name, ".")
 	}
 	return name
+}
+
+// AutoHashLabeler When a label value is too long ( > 63 chars), send a hash of the string instead
+func AutoHashLabeler(s string) string {
+	if len(s) > 63 {
+		hash := md5.Sum([]byte(s))
+		return hex.EncodeToString(hash[:])
+	}
+	return s
 }
 
 func IsSeq(arr []int, start *int) bool {


### PR DESCRIPTION
Fixes #169 

After considering that label selectors are the essentially the reason for the labels, I decided to not remove any label keys. Instead values > 63 chars are hashed under the original label key. This is backwards compatible and does not affect resource selections prior to this change.